### PR TITLE
Case-insensitive usernames

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -65,7 +65,9 @@ function authenticatedUserHandler(email, sender, username, password) {
   });
 }
 
-function createFirebaseUser(email, username, sender) {
+// displayName is what a user entered
+// all usernames are lowercase.
+function createFirebaseUser(email, displayName, username, sender) {
 
   var password = generatePassphrase();
 
@@ -86,7 +88,7 @@ function createFirebaseUser(email, username, sender) {
         email: email,
         emailVerified: false,
         password: password,
-        displayName: username,
+        displayName: displayName,
         disabled: false
       }).then((user) => {
         console.log("successfully created user " + username);
@@ -97,7 +99,7 @@ function createFirebaseUser(email, username, sender) {
     console.log(error);
     return Promise.reject(error);
   }).then((result) => {
-    return authenticatedUserHandler(email, sender, result.username, result.pass);
+    return authenticatedUserHandler(email, sender, username, result.pass);
   }).then((result) => {
     console.log("SUCCESS");
     return {success: true};
@@ -111,7 +113,7 @@ function createFirebaseUser(email, username, sender) {
 
 exports.createUserAndInvite = functions.https.onCall((data, context) => {
   var result =
-    createFirebaseUser(data.email, data.username, data.sender)
+    createFirebaseUser(data.email, data.username, data.username.toLowerCase(), data.sender)
 
   return result.then((result) => {
     return {success: result.success};

--- a/public/js/commonplay.js
+++ b/public/js/commonplay.js
@@ -26,16 +26,19 @@ window.addEventListener("load", function() {
 		// Note: if the user logs out, we should unset this.
 		var currentUser;
 		if (user === null || user === undefined) {
+      var name = "anonymous-" + Date.now();
 			currentUser = {
 				email: "unknown@null.void",
-				username: "anonymous-" + Date.now()
+				username: name,
+        displayName: name
 			};
 			document.getElementById("add-player").disabled = true;
 			document.getElementById("add-link").disabled = true;
 		} else {
 			currentUser = {
 				email: user.email,
-				username: user.displayName
+        displayName: user.displayName,
+				username: user.displayName.toLowerCase()
 			};
 		}
 
@@ -48,6 +51,7 @@ window.addEventListener("load", function() {
 			randomIndex: 1,
 			// id of the current user (same as ME)
 			selfId: currentUser.username,
+      displayName: currentUser.displayName,
 			// color picker
 			colorPicker: d3.scaleOrdinal(["#47ade0", "#be73e6", "#86e570", "#e466be", "#62b134", "#738ae8", "#db8f2e", "#4be0d9", "#ee5679", "#6de8a6",
 				"#ea6941", "#54b385", "#e07aa0", "#5dad5c", "#c792d6", "#90a44a", "#dc8869", "#cfe48c", "#caa74e"
@@ -497,14 +501,6 @@ window.addEventListener("load", function() {
 			document.getElementById("zoom-in").addEventListener("click", zoomIn);
 			document.getElementById("reset-button").addEventListener("click", resetZoom);
 			document.getElementById("zoom-out").addEventListener("click", zoomOut);
-
-			document.getElementById("add-player").addEventListener("click", function() {
-				// in case the user is anonymous
-				if(state.selfId) {
-					//db.weakenNode(state.selfId, ADD_PLAYER_DECREMENT_NODE_SCORE);
-					return true;
-				}
-			});
 
 			document.body.addEventListener("keydown", function(e) {
 				// console.log(e);

--- a/public/js/joinritualwin.js
+++ b/public/js/joinritualwin.js
@@ -209,7 +209,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
         validateAndSubmit(ev, emailEntered, usernameEntered);
 
-        database.userExists(usernameEntered).then(function(exists) {
+        database.userExists(usernameEntered.toLowerCase()).then(function(exists) {
           if (exists) {
             return Promise.reject(new Error("username-exists"));
           } else {
@@ -239,7 +239,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
         validateAndSubmit(ev, emailEntered, usernameEntered);
 
-        database.userExists(usernameEntered).then(function(exists) {
+        database.userExists(usernameEntered.toLowerCase()).then(function(exists) {
           if (!exists) {
             return Promise.reject(new Error("username-does-not-exist"));
           } else {


### PR DESCRIPTION
Broad idea is this:
* the `displayName` on the auth object remains the same; it's exactly
what the user entered (with whitespace trimmed off the front and back).
* the `username` is basically `displayName.toLowerCase()` and it's what
we store in the `/players` database.
* We use the lowercase username to check if a username already exists.